### PR TITLE
chore: update Android SDK to v4.1.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'io.rownd:android:4.1.0'
+  implementation 'io.rownd:android:4.1.1'
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0"
   implementation 'androidx.compose.ui:ui-unit:1.3.0'
   implementation 'androidx.compose.ui:ui-graphics:1.3.0'


### PR DESCRIPTION
## Overview
Updates the Rownd Android SDK dependency from v4.1.0 to v4.1.1 to include a critical bug fix that prevents fatal crashes in React Native applications.

## Problem Fixed
The previous version had a DataStore singleton pattern violation that caused this fatal crash:

```
java.lang.IllegalStateException: There are multiple DataStores active 
for the same file: /data/data/.../files/datastore/rownd_state.json
```

## Root Cause
- `StateRepo.defaultDataStore()` was creating new DataStore instances on every call
- Multiple DataStores accessing the same file violates Android DataStore requirements
- Triggered by component re-mounting, activity lifecycle changes, or hot reloads

## Solution in Android SDK v4.1.1
- ✅ Fixed singleton pattern with proper instance caching
- ✅ Added thread safety with `@Synchronized` annotation  
- ✅ Prevented memory leaks by using `applicationContext`
- ✅ Eliminated risky null assertions

## Impact
- **Before:** Fatal crashes for customers using React Native
- **After:** Stable, crash-free experience

## Changes
- `android/build.gradle`: Updated `io.rownd:android` from `4.1.0` → `4.1.1`

## Testing
- [x] Verified dependency update
- [x] No breaking API changes
- [x] Backward compatible

This resolves customer-reported production crashes and should be deployed immediately.