### PR TITLE
Add handleSignInLink for Android (feature parity with iOS)

### DIFF
--- a/android/src/main/java/com/reactnativerowndplugin/RowndPluginModule.kt
+++ b/android/src/main/java/com/reactnativerowndplugin/RowndPluginModule.kt
@@ -119,6 +119,26 @@ class RowndPluginModule(reactContext: ReactApplicationContext) : ReactContextBas
     }
 
     @ReactMethod
+    fun handleSignInLink(url: String) {
+      val activity = reactApplicationContext.currentActivity ?: return
+      activity.intent = android.content.Intent(
+        android.content.Intent.ACTION_VIEW,
+        android.net.Uri.parse(url)
+      )
+      try {
+        val apiGetter = Rownd.javaClass.getMethod("getSignInLinkApi\$android-release")
+        val api = apiGetter.invoke(Rownd)
+        val method = api.javaClass.getMethod(
+          "signInWithLinkIfPresentOnIntentOrClipboard\$android-release",
+          android.app.Activity::class.java
+        )
+        method.invoke(api, activity)
+      } catch (e: Exception) {
+        Log.e("RowndPlugin", "handleSignInLink failed: ${e.message}")
+      }
+    }
+
+    @ReactMethod
     fun requestSignIn(signInConfig: ReadableMap) {
       val rowndSignInOptions = RowndSignInOptions()
 

--- a/android/src/main/java/com/reactnativerowndplugin/RowndPluginModule.kt
+++ b/android/src/main/java/com/reactnativerowndplugin/RowndPluginModule.kt
@@ -134,7 +134,7 @@ class RowndPluginModule(reactContext: ReactApplicationContext) : ReactContextBas
         )
         method.invoke(api, activity)
       } catch (e: Exception) {
-        Log.e("RowndPlugin", "handleSignInLink failed: ${e.message}")
+        Log.e("RowndPlugin", "handleSignInLink failed", e)
       }
     }
 


### PR DESCRIPTION
`handleSignInLink` is implemented on iOS and called from the JS bridge (`GlobalContext.tsx`) for deep link sign-in, but has no Android implementation. This means deep link sign-in silently fails on Android.

Adds `@ReactMethod handleSignInLink(url)` to `RowndPluginModule.kt`. Uses reflection to call the internal `SignInLinkApi` since the Android SDK doesn't expose a public equivalent of iOS's `Rownd.handleSmartLink`.

## Summary by Sourcery

New Features:
- Expose a handleSignInLink(url) React Native method on Android to process deep link sign-in flows.